### PR TITLE
Fix build for Swift 4.0.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,62 @@
+
+# Created by https://www.gitignore.io/api/swift
+
+### Swift ###
+# Xcode
+#
+# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+
+## Build generated
+build/
+DerivedData/
+
+## Various settings
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+xcuserdata/
+
+## Other
+*.moved-aside
+*.xccheckout
+*.xcscmblueprint
+
+## Obj-C/Swift specific
+*.hmap
+*.ipa
+*.dSYM.zip
+*.dSYM
+
+## Playgrounds
+timeline.xctimeline
+playground.xcworkspace
+
+# Swift Package Manager
+#
+# Add this line if you want to avoid checking in source code from Swift Package Manager dependencies.
+# Packages/
+# Package.pins
+.build/
+
+# CocoaPods - Refactored to standalone file
+
+# Carthage - Refactored to standalone file
+
+# fastlane
+#
+# It is recommended to not store the screenshots in the git repo. Instead, use fastlane to re-generate the
+# screenshots whenever they are needed.
+# For more information about the recommended setup visit:
+# https://docs.fastlane.tools/best-practices/source-control/#source-control
+
+fastlane/report.xml
+fastlane/Preview.html
+fastlane/screenshots
+fastlane/test_output
+
+# End of https://www.gitignore.io/api/swift

--- a/Package.swift
+++ b/Package.swift
@@ -1,9 +1,10 @@
+// swift-tools-version:4.0
 import PackageDescription
 
 let package = Package(
     name: "SwiftBitset",
-    swiftLanguageVersions: [4],
     targets: [
-        Target(name: "Bitset", dependencies: [])
+        .target(name: "Bitset", dependencies: []),
+        .testTarget(name: "BitsetTests", dependencies: ["Bitset"])
     ]
 )

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ import PackageDescription
 let package = Package(
     name: "fun",
     dependencies: [
-   .Package(url: "https://github.com/lemire/SwiftBitset.git",  majorVersion: 0)
+   .package(url: "https://github.com/lemire/SwiftBitset.git",  from: "0.3.0")
     ]
 )
 ```

--- a/Sources/Bitset/Bitset.swift
+++ b/Sources/Bitset/Bitset.swift
@@ -4,12 +4,12 @@ infix operator &^=;// andNot
 
 private extension Int64 {
     func toUInt64() -> UInt64 { return UInt64(bitPattern:self) }
-    func toInt() -> Int { return Int(truncatingBitPattern:self) }
+    func toInt() -> Int { return Int(truncatingIfNeeded:self) }
 }
 
 private extension UInt64 {
     func toInt64() -> Int64 { return Int64(bitPattern:self) }
-    func toInt() -> Int { return Int(truncatingBitPattern:self) }
+    func toInt() -> Int { return Int(truncatingIfNeeded:self) }
 }
 
 // a class that can be used as an efficient set container for non-negative integers


### PR DESCRIPTION
First of all, thanks for sharing this OS project! 🎉 

Trying to set it up in a project I've found the following issue:

At first doing: `swift build`
```
error: manifest parse error(s):
/myProject/Package.swift:17:10: error: type 'Package.Dependency' has no member 'Package'
        .Package(url: "https://github.com/lemire/SwiftBitset.git", majorVersion: 0)
        ~^
```

After fixing that first issue (and some others related to some API changes with the latest Swift version), then I realized that there was no semantic version as explained [here](https://github.com/apple/swift-package-manager/blob/master/Documentation/Usage.md#publish-a-package) so I create a tag in my forked repo to be able to link it. 

Besides all that, there is also a `.gitignore` file to avoid tracking some files that are not required.