### PR TITLE
Export/import bitmap as byte data

### DIFF
--- a/Sources/Bitset/Bitset.swift
+++ b/Sources/Bitset/Bitset.swift
@@ -65,6 +65,7 @@ public final class Bitset: Sequence, Equatable, CustomStringConvertible,
       for i in elements { add(i) }
   }
 
+  // load a raw bitfield in little endian format, assumes each bit corresponds 1-to-1 to a value in the bitmap
   public init(bytes: Data) {
     if (bytes.count == 0) {
       data = UnsafeMutablePointer<UInt64>.allocate(capacity:capacity)
@@ -96,6 +97,8 @@ public final class Bitset: Sequence, Equatable, CustomStringConvertible,
     }
   }
 
+  // store raw bitset as uncompressed bytes, with the size being the minimum to store the most significant bit, and the
+  // bits in little endian order. if no bits are set, an empty instance is returned
   public func toData() -> Data {
     let heighestWord = self.heighestWord()
     if heighestWord < 0 { return Data() }

--- a/Sources/Bitset/Bitset.swift
+++ b/Sources/Bitset/Bitset.swift
@@ -65,8 +65,9 @@ public final class Bitset: Sequence, Equatable, CustomStringConvertible,
       for i in elements { add(i) }
   }
 
-  // load a raw bitfield in little endian format, assumes each bit corresponds 1-to-1 to a value in the bitmap
+  // load an uncompressed bitmap, in ascending order
   public init(bytes: Data) {
+    assert(Bitset.wordSize == 8) // this logic is expecting a 64-bit internal representation
     if (bytes.count == 0) {
       data = UnsafeMutablePointer<UInt64>.allocate(capacity:capacity)
       return
@@ -97,9 +98,10 @@ public final class Bitset: Sequence, Equatable, CustomStringConvertible,
     }
   }
 
-  // store raw bitset as uncompressed bytes, with the size being the minimum to store the most significant bit, and the
-  // bits in little endian order. if no bits are set, an empty instance is returned
+  // store as uncompressed bitmap in ascending order, with a bytes size that captures the most significant bits,
+  // or an empty instance if no bits are present
   public func toData() -> Data {
+    assert(Bitset.wordSize == 8) // this logic is expecting a 64-bit internal representation
     let heighestWord = self.heighestWord()
     if heighestWord < 0 { return Data() }
     let lastWord = Int64(bitPattern: data[heighestWord])

--- a/Tests/BitsetTests/BitsetTests.swift
+++ b/Tests/BitsetTests/BitsetTests.swift
@@ -369,7 +369,7 @@ class BitsetTests: XCTestCase {
   }
 
   func testDeserializationSmallPerformance() {
-    let raws = generateRandomBitsets(count: 800000, size32: 1)
+    let raws = generateRandomBitsets(count: 100000, size32: 1)
     var bitsets = [Bitset]()
     measure {
       raws.forEach { raw in


### PR DESCRIPTION
Hello @lemire ,

Thank you for your bitset implementation!  I've used it on a project recently, and I need to integrate with the Java implementation.  So I've added 2 new features: serialization and Carthage support (for which I'll provide a separate PR).

On the Java side I'm using `java.util.BitSet`, which exports a plain bitmap in little endian[0].  I added functions to your library to export to/import from this format, along with the expected verifications and performance measures in the test suite.  Starting from a naive implementation, I also made some performance optimisations within the limits of canonical Swift, and for the lack of assembler intrinsics.  The code compiles and tests according to your instructions.

If you find this a worthy addition to your library, it would be nice to see it hit upstream.  Let me know what you think.

Cheers,

Jarrod

[0] https://docs.oracle.com/javase/7/docs/api/java/util/BitSet.html#toByteArray()